### PR TITLE
Add contributing guidelines to README for session material submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@
 | Title | Speaker | Link |
 |-------|---------|------|
 |Flutter for the creative: Image to Story Generator with Gemini|[@iamEtornam](https://github.com/iamEtornam)|[Link](./sessions/00-StoryGenerator.md)|
+
+
+## Contributing
+
+- Fork this repository
+- Create a Branch with your addition or change
+    1. Create a slide deck for your talk with the [provided slide deck template](https://docs.google.com/presentation/d/1xciiCPJDlLiSXpvSOnWrDK-atCnGux7EreZ4giJIbdU/edit?usp=sharing). Please stick to this as we aim to ensure uniform branding for the event. For any questions please post them in the dedicated Speakers WhatsApp Group or [email us](gdgnairobi1@gmail.com).
+    2. Open the [Sessions Folder](https://github.com/GDGNairobi/BwAI-Nairobi-2025/tree/main/sessions).
+    3. Place your presentation material in the corresponding folder (speaker name + presentation name). If you can’t find the right folder, create a new one with your name and presentation name.
+    4. Create a markdown file with all the details and materials about your session. See [an example here](https://github.com/GDGNairobi/BwAI-Nairobi-2025/blob/main/sessions/Bright%20Sunu%20%7C%20Flutter%20for%20the%20Creative%3A%20Image%20to%20Story%20Generator%20with%20Gemini/00-StoryGenerator.md)
+        - Feel free to add any jargon / technical term / key sentence for volunteers and event atendees to be aware of that wouldn’t otherwise be in your slides.
+    5. Confirm you’ve added your material by creating a new row on the Table in this README with the title of your talk, your name and a link to the markdown file you created.
+- Submit a pull request with this repo as the upstream main
+- Your PR will be reviewed by the speaker committee and merged.
+
+**Note**: If you are a speaker with slides who isn't familiar with Git, please let the team know by droping a message in the dedicated speaker group or [sending us an email](gdgnairobi1@gmail.com)so that we can work with you on getting your materials linked here!


### PR DESCRIPTION
This pull request introduces a new "Contributing" section to the `README.md` file, providing guidelines for speakers on how to submit their presentation materials and session details. It includes step-by-step instructions to ensure uniformity and ease of contribution.

### Key Changes:

#### Contribution Updates:
* Added a "Contributing" section to the `README.md` with detailed steps for speakers to:
  - Fork the repository and create a branch for their changes.
  - Use the provided slide deck template for uniform branding.
  - Add their presentation materials and markdown file to the appropriate folder in the `sessions` directory, or create a new folder if necessary.
  - Update the session table in the `README.md` with their talk details and link to the markdown file.
  - Submit a pull request for review by the speaker committee.
* Included a note for speakers unfamiliar with Git, offering assistance via email or the speaker group.